### PR TITLE
Added SSH certificate verification

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -9,6 +9,7 @@ class PaypalNVP
   def initialize(sandbox = false, extras = {})
     type = sandbox ? "sandbox" : "live"
     config = YAML.load_file("#{RAILS_ROOT}/config/paypal.yml") rescue nil
+    @require_ssl_certs = (extras[:require_ssl_certs]!=nil)? extras[:require_ssl_certs] : true
     if config
       @url  = config[type]["url"] 
       @user = config[type]["user"]
@@ -35,7 +36,17 @@ class PaypalNVP
     uri = URI.parse(@url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+#    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+		rootCA = '/etc/ssl/certs'
+		if File.directory? rootCA
+			http.ca_path = rootCA
+			http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+			http.verify_depth = 5
+		else
+			raise "missing ssl certs. Cannot secure paypal communication" if (@require_ssl_certs == true)
+			puts "WARNING: no ssl certs found. Paypal communication will be insecure. DO NOT DEPLOY"
+			http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+		end
 
     response = http.start {
       http.request_get(uri.path + qs) {|res|


### PR DESCRIPTION
This should fix: https://github.com/solisoft/paypal_nvp/issues/closed#issue/1

I talked to a friend who works in security today who confirmed that this is definitely a bad thing so I guess I'd recommend pushing this out asap!

I tested it out on my sinatra app and it seems to function the same as the old version. I added the option to disable certificates but I would highly recommend not doing that unless you are only talking to the sandbox paypal server and even then there could be implications I don't fully understand.

One thing that is missing here is a windows implementation. I think this will even work on mac because it's unix-based but windows does this differently (ruby seems very non-windows oriented though so i guess this isn't a huge issue for now).

good reference material on how this MITM stuff works: http://en.wikipedia.org/wiki/Man-in-the-middle_attack

Cheers
