### PR TITLE
Change get to post

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -31,7 +31,7 @@ class PaypalNVP
     data.each do |key, value|
       qs << "#{key.to_s.upcase}=#{URI.escape(value)}"
     end
-    qs = "?#{qs * "&"}"    
+    qs = "#{qs * "&"}"    
     
     uri = URI.parse(@url)
     http = Net::HTTP.new(uri.host, uri.port)
@@ -49,7 +49,7 @@ class PaypalNVP
 		end
 
     response = http.start {
-      http.request_get(uri.path + qs) {|res|
+      http.request_post(uri.path, qs) {|res|
         res
       }
     }


### PR DESCRIPTION
This changes the call to request_get to use request_post instead, with the query parameters in the body of the post.

This fixes an issue that I ran into when using PayPal's SetExpressCheckout call where the number of characters in the query string is over 4000 characters. In such cases, SetExpressCheckout will immediately return with error code 10001 (L_LONGMESSAGE0: 'Timeout processing request'). The query string limit actually appears to vary, but is generally somewhere around the 3650 character mark.

Additionally, POST-ing requests with the data in the body is PayPal's suggested method of interacting with the NVP API, as per: https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_nvp_NVPAPIOverview
