### PR TITLE
Logger is declared as an instance variable but later on is called with a typo.

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -52,7 +52,7 @@ class PaypalNVP
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.verify_depth = 5
     else
-      logger.warn "[PaypalNVP] No ssl certs found. Paypal communication will be insecure. DO NOT DEPLOY"
+      @logger.warn "[PaypalNVP] No ssl certs found. Paypal communication will be insecure. DO NOT DEPLOY"
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
 


### PR DESCRIPTION
Missing '@' when calling the earlier declared @logger results in NameError in the case of missing SSL certificates instead of the more helpful warning message.
