### PR TITLE
Add escape of plus signs in parameters

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -38,7 +38,7 @@ class PaypalNVP
     data.merge!(@extras)
     qs = []
     data.each do |key, value|
-      qs << "#{key.to_s.upcase}=#{URI.escape(value.to_s)}"
+      qs << "#{key.to_s.upcase}=#{URI.escape(value.to_s, /\+/)}"
     end
     qs = "#{qs * "&"}"
 


### PR DESCRIPTION
Add escape of plus signs in parameters in order to accept alias emails (accepted by paypal)